### PR TITLE
Allow filtering by email, tag & ids through query parameters

### DIFF
--- a/Insightly-SDK/Insightly.cs
+++ b/Insightly-SDK/Insightly.cs
@@ -1479,19 +1479,47 @@ namespace InsightlySDK{
 				Console.WriteLine("FAIL: GetContacts()");
 				failed += 1;
 			}
-			
+            
 			// Test AddContact()
 			try{
 				var contact = new JObject();
 				contact["SALUTATION"] = "Mr";
 				contact["FIRST_NAME"] = "Testy";
 				contact["LAST_NAME"] = "McTesterson";
-				contact = this.AddContact(contact);
+
+                var contactInfos = new JArray();
+                var email = new JObject();
+                email["TYPE"] = "EMAIL";
+                email["LABEL"] = "Personal";
+                email["DETAIL"] = "test@example.com";
+                contactInfos.Add(email);
+                contact["CONTACTINFOS"] = contactInfos;
+
+                contact = this.AddContact(contact);
 				Console.WriteLine("PASS: AddContact()");
 				passed += 1;
-				
-				// Test DeleteContact()
-				try{
+
+                // Test GetContacts() by email
+                try
+                {
+                    var contacts = this.GetContacts(null, "test@example.com");
+
+                    if(contacts.Count != 1)
+                    {
+                        throw new Exception();
+                    }
+
+                    Console.WriteLine("PASS: GetContacts() by email, found " + contacts.Count + " contacts.");
+                    passed += 1;
+                }
+                catch (Exception){
+                    Console.WriteLine("FAIL: GetContacts() by email");
+                    failed += 1;
+                }
+
+                // Test DeleteContact()
+                try
+                {
 					this.DeleteContact(contact["CONTACT_ID"].Value<int>());
 					Console.WriteLine("PASS: DeleteContact()");
 					passed += 1;

--- a/Insightly-SDK/InsightlyRequest.cs
+++ b/Insightly-SDK/InsightlyRequest.cs
@@ -24,6 +24,7 @@ namespace InsightlySDK{
 		public Stream AsInputStream(){
 			var url = new UriBuilder(BASE_URL);
 			url.Path = this.url_path;
+            url.Query = this.QueryString;
 			
 			var request = WebRequest.Create(url.ToString());
 			request.Method = this.method.ToString();
@@ -116,7 +117,7 @@ namespace InsightlySDK{
 		private string QueryString{
 			get{
 				if(query_params.Count > 0){
-					return "?" + String.Join("&", query_params);
+					return String.Join("&", query_params);
 				}
 				else{
 					return "";


### PR DESCRIPTION
Previously the query parameters added by GetContacts (and presumably others) would end up unused in building the final query. This commit adds the query string to the requested uri. It also includes a test to exemplify filtering by email.